### PR TITLE
Removed the debugging call

### DIFF
--- a/lib/mdmagick.js
+++ b/lib/mdmagick.js
@@ -176,8 +176,6 @@ MDM.Utils = {
 }
 
 $(function(){
-  console.info( "loading MDMagick..." );
-
   jQuery.fn.mdmagick = function(){
     this.each( function( index, inputElement ){
       var mdm = new MDM( inputElement );


### PR DESCRIPTION
Displaying a message in the console each time the file is loaded is not nice for a prod environment (and even less nice in IE8 which will trigger an exception on the console call as it does not have the console object)
