### PR TITLE
added tabindex=“-1” on editor buttons elements. When you push "tab" butt...

### DIFF
--- a/lib/mdmagick.js
+++ b/lib/mdmagick.js
@@ -167,11 +167,11 @@ MDM.Utils = {
     var template =
       "<div class=\"mdm-buttons mdm-control\">" +
       "  <ul>" +
-      "    <li class=\"mdm-bold\"><a class=\"mdm-icon-bold\" href=\"#mdm-bold\"><span>B</span></a></li>" +
-      "    <li class=\"mdm-italic\"><a class=\"mdm-icon-italic\" href=\"#mdm-italic\"><span>I</span></a></li>" +
-      "    <li class=\"mdm-link\"><a class=\"mdm-icon-link\" href=\"#mdm-link\"><span>a</span></a></li>" +
-      "    <li class=\"mdm-list\"><a class=\"mdm-icon-list\" href=\"#mdm-list\"><span>l</span></a></li>" +
-      "    <li class=\"mdm-title\"><a class=\"mdm-icon-title\" href=\"#mdm-title\"><span>T</span></a></li>" +
+      "    <li class=\"mdm-bold\"><a tabindex=\"-1\" class=\"mdm-icon-bold\" href=\"#mdm-bold\"><span>B</span></a></li>" +
+      "    <li class=\"mdm-italic\"><a tabindex=\"-1\" class=\"mdm-icon-italic\" href=\"#mdm-italic\"><span>I</span></a></li>" +
+      "    <li class=\"mdm-link\"><a tabindex=\"-1\" class=\"mdm-icon-link\" href=\"#mdm-link\"><span>a</span></a></li>" +
+      "    <li class=\"mdm-list\"><a tabindex=\"-1\" class=\"mdm-icon-list\" href=\"#mdm-list\"><span>l</span></a></li>" +
+      "    <li class=\"mdm-title\"><a tabindex=\"-1\" class=\"mdm-icon-title\" href=\"#mdm-title\"><span>T</span></a></li>" +
       "  </ul>" +
       "</div>";
 


### PR DESCRIPTION
...on, focus state applies on all <a> elements in editor menu. It’s annoying because you need to push "tab" button until focus state go through all <a> elements and then it applies to needed text area or input.
